### PR TITLE
Add more database option

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -5,10 +5,41 @@ const { bold } = require('kleur')
 const fs = require('fs')
 const path = require('path')
 const execa = require('execa')
+const arg = require('arg')
+const os = require('os')
+
+const args = arg({
+  '--pg': String,
+  '--postgres': '--pg',
+  '--mysql': String,
+  '--sqlite': String,
+})
+
+function changeDatabaseType(type, url) {
+  const schemaPath = path.join(process.cwd(), 'prisma', 'schema.prisma')
+  const envPath = path.join(process.cwd(), 'prisma', '.env')
+
+  const PROVIDER_REGEX = /^\s+provider\s+=\s+["']sqlite["']/m
+  const END_REGEX = /^DATABASE_URL=.+/m
+
+  const schema = fs.readFileSync(schemaPath).toString()
+  const env = fs.readFileSync(envPath).toString()
+
+  const newProvider = `  provider = "${type}"`
+  const newURL = `DATABASE_URL=${url}`
+
+  const newSchema = schema.replace(PROVIDER_REGEX, newProvider)
+  const newEnv = env.replace(END_REGEX, newURL)
+
+  fs.writeFileSync(schemaPath, newSchema)
+  fs.writeFileSync(envPath, newEnv)
+}
 
 async function main() {
   const projects = fs.readdirSync(path.join(__dirname, 'projects'))
-  if (!process.argv[2]) {
+  const command = args._[0]
+
+  if (!command) {
     throw new Error(`Please provide a template with ${bold(
       'auto PROJECT_NAME',
     )}.
@@ -33,10 +64,71 @@ ${cwdFiles.join('\n')}`)
     recursive: true,
   })
 
-  await execa.command('yarn add @prisma/client@alpha @prisma/cli@alpha', {
-    stdio: 'inherit',
-    shell: true,
-  })
+  switch (command) {
+    case 'prisma': {
+      const configPath = path.join(os.homedir(), '.autorc.json')
+      const configExists = fs.existsSync(configPath)
+      let config
+      if (configExists) {
+        config = fs.readFileSync(configPath)
+        config = JSON.parse(config)
+      } else {
+        console.log(
+          `No config found, I will fallback to defaults. I looked for config at ${bold(
+            configPath,
+          )}`,
+        )
+      }
+      console.log(config)
+      if (args['--pg']) {
+        // deleting the sqlite database
+        fs.unlinkSync(path.join(process.cwd(), 'prisma', 'dev.db'))
+        // add the database name
+        let database
+        if (config && config.prisma && config.prisma.postgres) {
+          database = `${config.prisma.postgres}${
+            config.prisma.postgres.endsWith('/') ? '' : '/'
+          }${args['--pg']}`
+          console.log(database)
+        } else {
+          console.log('Using default pg url')
+          database =
+            'postgresql://postgres:postgres@localhost:5432/' + args['--pg']
+        }
+        changeDatabaseType('postgresql', database)
+      }
+      if (args['--mysql']) {
+        // deleting the sqlite database
+        fs.unlinkSync(path.join(process.cwd(), 'prisma', 'dev.db'))
+        // add the database name
+        let database
+        if (config && config.prisma && config.prisma.mysql) {
+          database = `${config.prisma.mysql}${
+            config.prisma.mysql.endsWith('/') ? '' : '/'
+          }${args['--mysql']}`
+        } else {
+          console.log('Using default mysql url')
+          database = 'mysql://root:root@localhost:5432/' + args['--mysql']
+        }
+        changeDatabaseType('mysql', database)
+      }
+      if (args['--sqlite']) {
+        // deleting the sqlite database
+        fs.unlinkSync(path.join(process.cwd(), 'prisma', 'dev.db'))
+        console.log('Using default sqlite url')
+        database = 'file:' + args['--sqlite']
+        changeDatabaseType('sqlite', database)
+      }
+      if (!args['--pg'] && !args['--sqlite'] && !args['--mysql']) {
+        console.log(`Falling back to ${bold('sqlite')}`)
+      }
+
+      await execa.command('yarn add @prisma/client@alpha @prisma/cli@alpha', {
+        stdio: 'inherit',
+        shell: true,
+      })
+    }
+  }
 }
 
 main().catch((e) => console.error(e.message))

--- a/bin.js
+++ b/bin.js
@@ -96,7 +96,6 @@ ${cwdFiles.join('\n')}`)
           database = `${config.prisma.postgres}${
             config.prisma.postgres.endsWith('/') ? '' : '/'
           }${args['--pg']}`
-          console.log(database)
         } else {
           console.log('Using default pg url')
           database = DEFAULT_POSTGRES_URL + args['--pg']

--- a/bin.js
+++ b/bin.js
@@ -16,7 +16,7 @@ const args = arg({
 })
 
 const DEFAULT_POSTGRES_URL = 'postgresql://postgres:postgres@localhost:5432/'
-const DEFAULT_MYSQL_URL = 'mysql://root:root@localhost:5432/'
+const DEFAULT_MYSQL_URL = 'mysql://root:root@localhost:3306/'
 
 function changeDatabaseType(type, url) {
   const schemaPath = path.join(process.cwd(), 'prisma', 'schema.prisma')

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@harshitpant/auto",
+  "name": "@timsuchanek/auto",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "@apexearth/copy": "^1.4.5",
+    "arg": "^4.1.3",
     "execa": "^4.0.0",
     "kleur": "^3.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@timsuchanek/auto",
+  "name": "@harshitpant/auto",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/projects/prisma/prisma/.env
+++ b/projects/prisma/prisma/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=file:dev.db

--- a/projects/prisma/prisma/schema.prisma
+++ b/projects/prisma/prisma/schema.prisma
@@ -4,7 +4,7 @@ generator client {
 
 datasource db {
   provider = "sqlite"
-  url      = "file:dev.db"
+  url      = env("DATABASE_URL")
 }
 
 model Post {

--- a/readme.md
+++ b/readme.md
@@ -13,9 +13,40 @@ This is not an official Prisma tool!
 
 ## Usage
 
+If you want to set the default url use, add the following config file to `~/.autorc.json`
+
+```json
+{
+  "prisma": {
+    "postgres": "postgresql://postgres:postgres@localhost:5432/",
+    "mysql": "mysql://root:root@localhost:3306/"
+  }
+}
+```
+
+Use default(spins up a sqlite project)
+
 ```bash
 mkdir test
 cd test
 npx @timsuchanek/auto prisma
+ts-node main.ts
+```
+
+Postgres
+
+```bash
+mkdir test
+cd test
+npx @timsuchanek/auto prisma --pg DATABASE_NAME
+ts-node main.ts
+```
+
+MySQL
+
+```bash
+mkdir test
+cd test
+npx @timsuchanek/auto prisma --mysql DATABASE_NAME
 ts-node main.ts
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@
     prettysize "^2.0.0"
     sleep-promise "^8.0.1"
 
+arg@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 commander@^2.19.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"


### PR DESCRIPTION
Thanks for the tool, I am going to use this every day  😄 

This PR adds support for more databases for the `prisma` project. It does so via CLI flags.

You can also change the default database use via a config file stored at `~/.autorc.json` and it follows the following structure:
```
{
  "prisma": {
    "postgres": "postgresql://postgres:postgres@localhost:5432/",
    "mysql": "mysql://root:root@localhost:3306/"
  }
}
```

Default functionality remains the same. Please merge this and release the tool :) 