### PR TITLE
fix: remove outdated method names

### DIFF
--- a/projects/prisma/main.ts
+++ b/projects/prisma/main.ts
@@ -1,11 +1,11 @@
 import { PrismaClient } from '@prisma/client'
 
 async function main() {
-  const client = new PrismaClient()
+  const prisma = new PrismaClient()
 
-  const data = await client.user.findMany()
+  const data = await prisma.user.findMany()
   console.log(data)
-  client.disconnect()
+  prisma.$disconnect()
 }
 
 main()


### PR DESCRIPTION
This PR adds `$` to disconnect to prevent deprecation warnings.

This also change instance name from `client` to `prisma` as that is more common among users.